### PR TITLE
Fix tile link template to work over httpS

### DIFF
--- a/docs/terrovizm.map.js
+++ b/docs/terrovizm.map.js
@@ -11,7 +11,7 @@
                 L.latLng(100, -200),
                  L.latLng(-100, 200));
 
-            L.tileLayer('http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png', {
+            L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
                 attribution: 'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(this.map);
 


### PR DESCRIPTION
Noticed the map tiles were not rendering at all so did a bit of investigation and found that the old template link for tiles was over http and the browser does not like it. 

Replaced old template with new template over https as suggested in this discussion in the Stamen Github repo: https://github.com/stamen/maps.stamen.com/issues/67 

Before: 
<img width="1440" alt="Screen Shot 2021-08-20 at 23 32 22" src="https://user-images.githubusercontent.com/13137224/130299707-72dcd30e-fb2a-4c1d-8652-322bd8d62d1d.png">

After:
<img width="1438" alt="Screen Shot 2021-08-20 at 23 31 59" src="https://user-images.githubusercontent.com/13137224/130299717-8b05eb4a-6fcd-4ebf-b87b-e3e312882637.png">


Offtopic: Github's in-browser VS Code is pretty neat for small changes like this! I didn't even have to check out repo locally